### PR TITLE
OmniGears: order header pack names

### DIFF
--- a/src/org/omnirom/omnigears/interfacesettings/StyleSettings.java
+++ b/src/org/omnirom/omnigears/interfacesettings/StyleSettings.java
@@ -55,6 +55,9 @@ import static android.provider.Settings.System.DOUBLE_TAP_SLEEP_GESTURE;
 
 import java.util.List;
 import java.util.ArrayList;
+import java.util.Map;
+import java.util.HashMap;
+import java.util.Collections;
 
 import org.omnirom.omnigears.preference.SystemCheckBoxPreference;
 import org.omnirom.omnigears.preference.SeekBarPreference;
@@ -182,37 +185,41 @@ public class StyleSettings extends SettingsPreferenceFragment implements
     }
 
     private void getAvailableHeaderPacks(List<String> entries, List<String> values) {
+        String defaultLabel = null;
+        Map<String, String> headerMap = new HashMap<String, String>();
         Intent i = new Intent();
         PackageManager packageManager = getPackageManager();
         i.setAction("org.omnirom.DaylightHeaderPack");
         for (ResolveInfo r : packageManager.queryIntentActivities(i, 0)) {
             String packageName = r.activityInfo.packageName;
-            if (packageName.equals(DEFAULT_HEADER_PACKAGE)) {
-                values.add(0, packageName);
-            } else {
-                values.add(packageName);
-            }
             String label = r.activityInfo.loadLabel(getPackageManager()).toString();
             if (label == null) {
                 label = r.activityInfo.packageName;
             }
             if (packageName.equals(DEFAULT_HEADER_PACKAGE)) {
-                entries.add(0, label);
+                defaultLabel = label;
             } else {
-                entries.add(label);
+                headerMap.put(label, packageName);
             }
         }
         i.setAction("org.omnirom.DaylightHeaderPack1");
         for (ResolveInfo r : packageManager.queryIntentActivities(i, 0)) {
             String packageName = r.activityInfo.packageName;
-            values.add(packageName  + "/" + r.activityInfo.name);
-
             String label = r.activityInfo.loadLabel(getPackageManager()).toString();
             if (label == null) {
                 label = packageName;
             }
-            entries.add(label);
+            headerMap.put(label, packageName  + "/" + r.activityInfo.name);
         }
+        List<String> labelList = new ArrayList<String>();
+        labelList.addAll(headerMap.keySet());
+        Collections.sort(labelList);
+        for (String label : labelList) {
+            entries.add(label);
+            values.add(headerMap.get(label));
+        }
+        entries.add(0, defaultLabel);
+        values.add(0, DEFAULT_HEADER_PACKAGE);
     }
 
     private boolean isBrowseHeaderAvailable() {


### PR DESCRIPTION
same ordering as in the browse activity

Change-Id: I5ebab981667075b52464551d2f9a71a1bc6ce987