### PR TITLE
OmniGears: ignore duplicate weather icon packs in selection dialog

### DIFF
--- a/src/org/omnirom/omnigears/moresettings/OmniJawsSettings.java
+++ b/src/org/omnirom/omnigears/moresettings/OmniJawsSettings.java
@@ -122,15 +122,19 @@ public class OmniJawsSettings extends SettingsPreferenceFragment implements
         i.setAction("org.omnirom.WeatherIconPack");
         for (ResolveInfo r : packageManager.queryIntentActivities(i, 0)) {
             String packageName = r.activityInfo.packageName;
+            String label = r.activityInfo.loadLabel(getPackageManager()).toString();
+            if (label == null) {
+                label = r.activityInfo.packageName;
+            }
+            if (entries.contains(label)) {
+                continue;
+            }
             if (packageName.equals(DEFAULT_WEATHER_ICON_PACKAGE)) {
                 values.add(0, r.activityInfo.name);
             } else {
                 values.add(r.activityInfo.name);
             }
-            String label = r.activityInfo.loadLabel(getPackageManager()).toString();
-            if (label == null) {
-                label = r.activityInfo.packageName;
-            }
+
             if (packageName.equals(DEFAULT_WEATHER_ICON_PACKAGE)) {
                 entries.add(0, label);
             } else {
@@ -141,11 +145,15 @@ public class OmniJawsSettings extends SettingsPreferenceFragment implements
         i.addCategory(CHRONUS_ICON_PACK_INTENT);
         for (ResolveInfo r : packageManager.queryIntentActivities(i, 0)) {
             String packageName = r.activityInfo.packageName;
-            values.add(packageName + ".weather");
             String label = r.activityInfo.loadLabel(getPackageManager()).toString();
             if (label == null) {
                 label = r.activityInfo.packageName;
             }
+            if (entries.contains(label)) {
+                continue;
+            }
+            values.add(packageName + ".weather");
+
             entries.add(label);
         }
     }


### PR DESCRIPTION
Change-Id: I0c3c1826eeed210587fa88280d86498a55e1fe6b