### PR TITLE
[2/2] OmniGears: Activate battery light on full battery

### DIFF
--- a/res/values-de/custom_strings.xml
+++ b/res/values-de/custom_strings.xml
@@ -140,6 +140,7 @@
   <string name="batterylight_title">Akku-LED-Einstellungen</string>
   <string name="battery_light_enable">Aktivieren</string>
   <string name="battery_low_pulse_title">Bei schwachem Akku blinken</string>
+  <string name="battery_light_only_full_charge_title">Erst bei voll geladenem Akku leuchten</string>
   <string name="battery_light_list_title">Farben</string>
   <string name="battery_light_low_color_title">Akku schwach</string>
   <string name="battery_light_medium_color_title">Akku wird geladen</string>

--- a/res/values/custom_strings.xml
+++ b/res/values/custom_strings.xml
@@ -160,6 +160,7 @@
     <string name="batterylight_title">Battery LED settings</string>
     <string name="battery_light_enable">Enable</string>
     <string name="battery_low_pulse_title">Pulse if battery low</string>
+    <string name="battery_light_only_full_charge_title">Only light up when fully charged</string>
     <string name="battery_light_list_title">Colors</string>
     <string name="battery_light_low_color_title">Battery low</string>
     <string name="battery_light_medium_color_title">Charging</string>

--- a/res/xml/battery_light_settings.xml
+++ b/res/xml/battery_light_settings.xml
@@ -32,6 +32,11 @@
             android:dependency="battery_light_enabled"
             android:persistent="false" />
 
+        <org.omnirom.omnigears.preference.SystemSettingSwitchPreference
+            android:key="battery_light_only_fully_charged"
+            android:title="@string/battery_light_only_full_charge_title"
+            android:dependency="battery_light_enabled" />
+
     </PreferenceCategory>
 
     <PreferenceCategory

--- a/src/org/omnirom/omnigears/batterylight/BatteryLightSettings.java
+++ b/src/org/omnirom/omnigears/batterylight/BatteryLightSettings.java
@@ -51,10 +51,12 @@ public class BatteryLightSettings extends SettingsPreferenceFragment implements
     private static final String REALLY_FULL_COLOR_PREF = "really_full_color";
     private static final String BATTERY_LIGHT_PREF = "battery_light_enabled";
     private static final String BATTERY_PULSE_PREF = "battery_light_pulse";
+    private static final String BATTERY_LIGHT_ONLY_FULL_PREF = "battery_light_only_fully_charged";
 
     private boolean mMultiColorLed;
     private SystemSettingSwitchPreference mEnabledPref;
     private SystemSettingSwitchPreference mPulsePref;
+    private SystemSettingSwitchPreference mOnlyFullPref;
     private PreferenceGroup mColorPrefs;
     private BatteryLightPreference mLowColorPref;
     private BatteryLightPreference mMediumColorPref;
@@ -91,6 +93,9 @@ public class BatteryLightSettings extends SettingsPreferenceFragment implements
         mPulsePref.setChecked(Settings.System.getInt(resolver,
                         Settings.System.BATTERY_LIGHT_PULSE, mBatteryLightEnabled ? 1 : 0) != 0);
         mPulsePref.setOnPreferenceChangeListener(this);
+
+        mOnlyFullPref = (SystemSettingSwitchPreference)prefSet.findPreference(BATTERY_LIGHT_ONLY_FULL_PREF);
+        mOnlyFullPref.setOnPreferenceChangeListener(this);
 
         // Does the Device support changing battery LED colors?
         if (getResources().getBoolean(com.android.internal.R.bool.config_multiColorBatteryLed)) {
@@ -206,6 +211,7 @@ public class BatteryLightSettings extends SettingsPreferenceFragment implements
     protected void resetToDefaults() {
         if (mEnabledPref != null) mEnabledPref.setChecked(true);
         if (mPulsePref != null) mPulsePref.setChecked(false);
+        if (mOnlyFullPref != null) mOnlyFullPref.setChecked(false);
 
         resetColors();
     }
@@ -220,6 +226,18 @@ public class BatteryLightSettings extends SettingsPreferenceFragment implements
             boolean value = (Boolean) objValue;
             Settings.System.putInt(getActivity().getContentResolver(),
                     Settings.System.BATTERY_LIGHT_PULSE, value ? 1:0);
+        } else if (preference == mOnlyFullPref) {
+            boolean value = (Boolean) objValue;
+            // If enabled, disable all but really full color preference.
+            if (mLowColorPref != null) {
+                mLowColorPref.setEnabled(!value);
+            }
+            if (mMediumColorPref != null) {
+                mMediumColorPref.setEnabled(!value);
+            }
+            if (mFullColorPref != null) {
+                mFullColorPref.setEnabled(!value);
+            }
         } else {
             BatteryLightPreference lightPref = (BatteryLightPreference) preference;
             updateValues(lightPref.getKey(), lightPref.getColor());
@@ -248,6 +266,7 @@ public class BatteryLightSettings extends SettingsPreferenceFragment implements
                     if (!res.getBoolean(com.android.internal.R.bool.config_intrusiveBatteryLed)) {
                         result.add(BATTERY_LIGHT_PREF);
                         result.add(BATTERY_PULSE_PREF);
+                        result.add(BATTERY_LIGHT_ONLY_FULL_PREF);
                     }
                     if (!res.getBoolean(com.android.internal.R.bool.config_multiColorBatteryLed)) {
                         result.add(LOW_COLOR_PREF);


### PR DESCRIPTION
Depends on battery light enabled. If set, the light will not
be activated on charge before the battery has been fully charged.

Change-Id: I80a4b329fcc20f7e0b057c68e6db76755ffb94bd